### PR TITLE
Fix annotations editor (at least for Grafana 9.1.3+).

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -6,6 +6,7 @@ import { switchMap, map } from 'rxjs/operators';
 export class DataSource extends DataSourceWithBackend<SnowflakeQuery, SnowflakeOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<SnowflakeOptions>) {
     super(instanceSettings);
+    this.annotations = {};
   }
 
   applyTemplateVariables(query: SnowflakeQuery, scopedVars: ScopedVars): SnowflakeQuery {


### PR DESCRIPTION
Without this change, the annotation query editor would not display on Grafana 9.1.3.