### PR TITLE
Convert long frame to wide frame

### DIFF
--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"strings"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 func equalsIgnoreCase(s []string, str string) bool {


### PR DESCRIPTION
This PR adds the support to convert a Long formatted time series Frame to a Wide format. The main functionality is done by calling function LongToWide() from "github.com/grafana/grafana-plugin-sdk-go/data" package. For the full description of this function, check the function description in the package source code.

One of the major purpose of this PR is to adding field labels to frame, which is required when apply "Labels to fields" transformation.

Fixes: #15, fixes: #19