### PR TITLE
Fix LIMIT condition to avoid duplicate LIMIT keyword.

### DIFF
--- a/pkg/query.go
+++ b/pkg/query.go
@@ -212,7 +212,7 @@ func (td *SnowflakeDatasource) query(dataQuery backend.DataQuery, config pluginC
 	}
 
 	// Add max Datapoint LIMIT option for time series
-	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
+	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && !strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
 		queryConfig.FinalQuery = fmt.Sprintf("%s LIMIT %d", queryConfig.FinalQuery, queryConfig.MaxDataPoints)
 	}
 


### PR DESCRIPTION
Add a default limit as the width of the panel.
Closes #26 