### PR TITLE
fix_23+25: concatenate name with labels for wide time series format and increase row limit to 1M

### DIFF
--- a/pkg/query.go
+++ b/pkg/query.go
@@ -43,7 +43,6 @@ var float float64
 var str string
 var integer int64
 
-
 // Constant used to describe the time series fill mode if no value has been seen
 const (
 	NullFill     = "null"
@@ -212,13 +211,12 @@ func (td *SnowflakeDatasource) query(dataQuery backend.DataQuery, config pluginC
 		return response
 	}
 
-	frame := data.NewFrame("")
-
 	// Add max Datapoint LIMIT option for time series
-	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
+	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && !strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
 		queryConfig.FinalQuery = fmt.Sprintf("%s LIMIT %d", queryConfig.FinalQuery, queryConfig.MaxDataPoints)
 	}
 
+	frame := data.NewFrame("")
 	dataResponse, err := queryConfig.fetchData(&config, password, privateKey)
 	if err != nil {
 		response.Error = err
@@ -350,4 +348,3 @@ func fillTimesSeries(queryConfig queryConfigStruct, intervalStart int64, interva
 		}
 	}
 }
-


### PR DESCRIPTION
* In order to display proper names in wide time series format concat column name with labels (only if any)
* Increate the row limit to 1M