### PR TITLE
[48] do not LIMIT for timeseries data at all

### DIFF
--- a/pkg/query.go
+++ b/pkg/query.go
@@ -211,11 +211,6 @@ func (td *SnowflakeDatasource) query(dataQuery backend.DataQuery, config pluginC
 		return response
 	}
 
-	// Add max Datapoint LIMIT option for time series
-	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && !strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
-		queryConfig.FinalQuery = fmt.Sprintf("%s LIMIT %d", queryConfig.FinalQuery, queryConfig.MaxDataPoints)
-	}
-
 	frame := data.NewFrame("")
 	dataResponse, err := queryConfig.fetchData(&config, password, privateKey)
 	if err != nil {


### PR DESCRIPTION
* Do not depend on maxDataPoints
* If the query contains LIMIT we set or else we get everything until maxrows
* We will let grafana to take care of timeseries slicing. We do not limit the data to display