### PR TITLE
[48] do not LIMIT for timeseries data at all

### DIFF
--- a/pkg/query.go
+++ b/pkg/query.go
@@ -214,11 +214,6 @@ func (td *SnowflakeDatasource) query(dataQuery backend.DataQuery, config pluginC
 	// Remove final semi column
 	queryConfig.FinalQuery = strings.TrimSuffix(strings.TrimSpace(queryConfig.FinalQuery), ";")
 
-	// Add max Datapoint LIMIT option for time series
-	if queryConfig.MaxDataPoints > 0 && queryConfig.isTimeSeriesType() && !strings.Contains(queryConfig.FinalQuery, "LIMIT ") {
-		queryConfig.FinalQuery = fmt.Sprintf("%s LIMIT %d", queryConfig.FinalQuery, queryConfig.MaxDataPoints)
-	}
-
 	frame := data.NewFrame("")
 	dataResponse, err := queryConfig.fetchData(&config, password, privateKey)
 	if err != nil {


### PR DESCRIPTION
* Do not limit timerseries data unless query contains LIMIT. So, we do not need this check
* Let grafana do the time slicing and display all data received in that time bucket