### PR TITLE
Fix: Ensure slice_length is an Integer >= 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.1
+
+### 🐞 Bug Fixes
+- The slice_length must be an integer greater than or equal to 1.
+
 ## 1.5.0
 
 ### 🐞 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "michelin-snowflake-datasource",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Data source for Snowflake",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",

--- a/pkg/macros.go
+++ b/pkg/macros.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,7 +114,7 @@ func evaluateMacro(name string, args []string, configStruct *queryConfigStruct) 
 			}
 		}
 
-		return fmt.Sprintf("TIME_SLICE(TO_TIMESTAMP_NTZ(%s), %v, 'SECOND', 'START')", args[0], interval.Seconds()), nil
+		return fmt.Sprintf("TIME_SLICE(TO_TIMESTAMP_NTZ(%s), %v, 'SECOND', 'START')", args[0], math.Max(1, interval.Seconds())), nil
 	case "__timeGroupAlias":
 		tg, err := evaluateMacro("__timeGroup", args, configStruct)
 		if err == nil {

--- a/pkg/macros_test.go
+++ b/pkg/macros_test.go
@@ -46,6 +46,7 @@ func TestEvaluateMacro(t *testing.T) {
 		{name: "__timeGroup", args: []string{}, err: "macro __timeGroup needs time column and interval and optional fill value"},
 		{name: "__timeGroup", args: []string{"col", "xxxx"}, err: "error parsing interval xxxx"},
 		{name: "__timeGroup", args: []string{"col", "1d"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')"},
+		{name: "__timeGroup", args: []string{"col", "500ms"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 1, 'SECOND', 'START')"},
 		{name: "__timeGroup", args: []string{"col", "1d", "NULL"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: NullFill},
 		{name: "__timeGroup", args: []string{"col", "1d", "previous"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: PreviousFill},
 		{name: "__timeGroup", args: []string{"col", "1d", "12"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: ValueFill, fillValue: 12},


### PR DESCRIPTION
This MR addresses a bug where the slice_length parameter was not properly validated. 
We now ensure that slice_length is an integer and is greater than or equal to 1.

Fix #60 