### PR TITLE
Fix for pivoting empty datasets

### DIFF
--- a/pkg/query.go
+++ b/pkg/query.go
@@ -289,6 +289,7 @@ func (td *SnowflakeDatasource) query(ctx context.Context, dataQuery backend.Data
 			frame, err = data.LongToWide(frame, fillMode)
 			if err != nil {
 				log.DefaultLogger.Error("Could not convert long frame to wide frame", "err", err)
+				frame = data.NewFrame("")
 			}
 			for _, field := range frame.Fields {
 				if field.Labels != nil {


### PR DESCRIPTION
Removes plugin crashes for time series plots with empty datasets. As in https://github.com/michelin/snowflake-grafana-datasource/issues/53