### PR TITLE
Add support for custom “display names” in Template Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 1.8.1
+## 1.9.0
 
 ### ⭐ Added
 - Template Variable: custom “display names” support with `__text` & `__value`
+
+## 1.8.1
 
 ### 🐞 Bug Fixes
 - Resolve the issue of reusing closed connections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.8.1
 
+### ⭐ Added
+- Template Variable: custom “display names” support with `__text` & `__value`
+
 ### 🐞 Bug Fixes
 - Resolve the issue of reusing closed connections.
 

--- a/README.md
+++ b/README.md
@@ -145,13 +145,12 @@ SELECT column FROM table WHERE column in ${variable:regex}
 SELECT column FROM table WHERE column in (test1|test2)
 ```
 
-Add a Template Variable:
-You can use a SQL Query to define a template Variable (https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-a-query-variable)
-Add __text and __value columns to your query to support custom "display names"
+Add a Template Variable:<br/>
+You can use a SQL Query to define a [Template Variable](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-a-query-variable)<br/>
 ```sql
+-- Add __text and __value columns to your query to support custom "display names"
 SELECT value_column as __value, text_column as __text FROM table 
 ```
-
 
 ##### Layout of a query
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ SELECT column FROM table WHERE column in ${variable:regex}
 SELECT column FROM table WHERE column in (test1|test2)
 ```
 
+Add a Template Variable:
+You can use a SQL Query to define a template Variable (https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-a-query-variable)
+Add __text and __value columns to your query to support custom "display names"
+```sql
+SELECT value_column as __value, text_column as __text FROM table 
+```
+
+
 ##### Layout of a query
 
 *Simple query*


### PR DESCRIPTION
This enables the plugin to add text / value based Template Variables to dashboards.
We use the std. query syntax as described in the grafana docs by using __text and __value column names to use the feature.
See: https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-a-query-variable

