### PR TITLE
QueryEscape username and password to match gosnowflake parsing≈

### DIFF
--- a/pkg/snowflake.go
+++ b/pkg/snowflake.go
@@ -109,9 +109,9 @@ func getConnectionString(config *pluginConfig, password string, privateKey strin
 	if len(privateKey) != 0 {
 		params.Add("authenticator", "SNOWFLAKE_JWT")
 		params.Add("privateKey", privateKey)
-		userPass = url.User(config.Username).String()
+		userPass = url.QueryEscape(config.Username)
 	} else {
-		userPass = url.UserPassword(config.Username, password).String()
+		userPass = url.QueryEscape(config.Username) + ":" + url.QueryEscape(password)
 	}
 
 	return fmt.Sprintf("%s@%s?%s&%s", userPass, config.Account, params.Encode(), config.ExtraConfig)


### PR DESCRIPTION
fixes issue #75 by escaping the username and password the same way the gosnowflake library unescapes them when parsing the connection string/DSN