### PR TITLE
Resolve the issue where source query variables are replaced with hardcoded values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### ⭐ Added
 - Add a query tag that includes relevant Grafana context information.
 
+### 🐞 Bug Fixes
+- Source query variables are replaced with hardcoded values in the query editor UI.
 
 ## 1.9.1
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,19 +1,24 @@
-import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
-import { DataQueryRequest, DataFrame, MetricFindValue, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
-import { SnowflakeQuery, SnowflakeOptions } from './types';
-import { switchMap, map } from 'rxjs/operators';
-import { firstValueFrom } from 'rxjs';
-import { uniqBy } from 'lodash';
+import {DataSourceWithBackend, getTemplateSrv, TemplateSrv} from '@grafana/runtime';
+import {DataFrame, DataQueryRequest, DataSourceInstanceSettings, MetricFindValue, ScopedVars} from '@grafana/data';
+import {SnowflakeOptions, SnowflakeQuery} from './types';
+import {map, switchMap} from 'rxjs/operators';
+import {firstValueFrom} from 'rxjs';
+import {uniqBy} from 'lodash';
 
 export class DataSource extends DataSourceWithBackend<SnowflakeQuery, SnowflakeOptions> {
-  constructor(instanceSettings: DataSourceInstanceSettings<SnowflakeOptions>) {
+
+  constructor(instanceSettings: DataSourceInstanceSettings<SnowflakeOptions>,
+      private readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
     super(instanceSettings);
     this.annotations = {};
   }
 
   applyTemplateVariables(query: SnowflakeQuery, scopedVars: ScopedVars): SnowflakeQuery {
-    query.queryText = getTemplateSrv().replace(query.queryText, scopedVars);
-    return query;
+    return {
+      ...query,
+      queryText: this.templateSrv.replace(query.queryText, scopedVars),
+    }
   }
 
   filterQuery(query: SnowflakeQuery): boolean {


### PR DESCRIPTION
Resolve the issue where source query variables are replaced with hardcoded values in the query editor UI.

Fix #104