### PR TITLE
improve weekly group handling

### DIFF
--- a/pkg/query/macros_test.go
+++ b/pkg/query/macros_test.go
@@ -59,6 +59,8 @@ func TestEvaluateMacro(t *testing.T) {
 		{name: "__timeGroup", args: []string{"col", "1d", "NULL"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: NullFill},
 		{name: "__timeGroup", args: []string{"col", "1d", "previous"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: PreviousFill},
 		{name: "__timeGroup", args: []string{"col", "1d", "12"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 86400, 'SECOND', 'START')", fillMode: ValueFill, fillValue: 12},
+		{name: "__timeGroup", args: []string{"col", "7d"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 1, 'WEEK', 'START')"},
+		{name: "__timeGroup", args: []string{"col", "2w"}, response: "TIME_SLICE(TO_TIMESTAMP_NTZ(col), 2, 'WEEK', 'START')"},
 		// __timeGroupAlias
 		{name: "__timeGroupAlias", args: []string{}, err: "macro __timeGroup needs time column and interval and optional fill value"},
 		{name: "__timeGroupAlias", args: []string{"col", "xxxx"}, err: "error parsing interval xxxx"},


### PR DESCRIPTION
**Problem**

Currently intervals such as 1w or 7d start on thursdays, because the `TIME_SLICE` that is using `START` and is based on seconds uses `1970-01-01` as it's starting point. This is not ideal in many reporting scenarios and makes the macro not as useful as it can be.

**Proposed solution**

For all intervals that translate directly to weeks use `TIME_SLICE` with `WEEK` basis, then it will be using `WEEK_START` session parameter which users can specify at connector level(or globally).

**Context**
Based on Snowflake Usage Notes: https://docs.snowflake.com/en/sql-reference/functions/time_slice#usage-notes