### PR TITLE
chore: update Go to v1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/michelin/snowflake-grafana-datasource
 
-go 1.24.1
+go 1.24.2
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/grafana/grafana-plugin-sdk-go v0.276.0


### PR DESCRIPTION
golang had been updated to `v1.24.1` for the planned `v2.2.0` release of the plugin in #157, but golang `v1.24.2` (released 2025-04-01) contains a fix for CVE-2025-22871 (published 2025-04-08). 

The GitHub Advisory Database classified this vulnerability as critical severity. As a result, vulnerability scans of targets built with affected toolchains are flagging this issue. 

Grafana `v11.6.1` (released 2025-04-23) also incudes a fix for this vulnerability. 

CHANGELOG for forthcoming `v2.2.0` already notes the upgrade to go `v1.24` without specifying a patch release.

Vulnerability reports:
* [CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871)
  *  [GitHub Advisory Database entry](https://github.com/advisories/GHSA-g9pc-8g42-g6vq)
* [GO-2025-3563](https://pkg.go.dev/vuln/GO-2025-3563)

See also: 
* #157
* [Grafana v11.6.1](https://github.com/grafana/grafana/releases/tag/v11.6.1)